### PR TITLE
Fix#10 middle click sorting invisible

### DIFF
--- a/src/main/java/net/kyrptonaught/inventorysorter/mixin/MixinAbstractContainerScreen.java
+++ b/src/main/java/net/kyrptonaught/inventorysorter/mixin/MixinAbstractContainerScreen.java
@@ -39,7 +39,7 @@ public abstract class MixinAbstractContainerScreen extends Screen implements Sor
         super(text_1);
     }
 
-    @Inject(method = "init", at = @At("TAIL"), cancellable = true)
+    @Inject(method = "init", at = @At("TAIL"))
     private void invsort$init(CallbackInfo callbackinfo) {
         if (InventorySorterMod.getConfig().displaySort) {
             boolean playerOnly = InventoryHelper.isPlayerOnlyInventory(this);
@@ -49,14 +49,14 @@ public abstract class MixinAbstractContainerScreen extends Screen implements Sor
         }
     }
 
-    @Inject(method = "mouseClicked", at = @At("HEAD"))
+    @Inject(method = "mouseClicked", at = @At("TAIL"))
     private void invsort$mouseClicked(double x, double y, int button, CallbackInfoReturnable callbackInfoReturnable) {
         if (InventorySorterMod.getConfig().middleClick && button == 2) {
             InventorySortPacket.sendSortPacket(InventoryHelper.isPlayerOnlyInventory(this));
         }
     }
 
-    @Inject(method = "keyPressed", at = @At("HEAD"))
+    @Inject(method = "keyPressed", at = @At("TAIL"))
     private void invsort$keyPressed(int keycode, int scancode, int modifiers, CallbackInfoReturnable callbackInfoReturnable) {
         if (InventorySorterMod.keyBinding.matchesKey(keycode, scancode)) {
             InventorySortPacket.sendSortPacket(InventoryHelper.isPlayerOnlyInventory(this));

--- a/src/main/java/net/kyrptonaught/inventorysorter/mixin/MixinAbstractContainerScreen.java
+++ b/src/main/java/net/kyrptonaught/inventorysorter/mixin/MixinAbstractContainerScreen.java
@@ -49,17 +49,19 @@ public abstract class MixinAbstractContainerScreen extends Screen implements Sor
         }
     }
 
-    @Inject(method = "mouseClicked", at = @At("TAIL"))
+    @Inject(method = "mouseClicked", at = @At("HEAD"), cancellable = true)
     private void invsort$mouseClicked(double x, double y, int button, CallbackInfoReturnable callbackInfoReturnable) {
         if (InventorySorterMod.getConfig().middleClick && button == 2) {
             InventorySortPacket.sendSortPacket(InventoryHelper.isPlayerOnlyInventory(this));
+            callbackInfoReturnable.cancel();
         }
     }
 
-    @Inject(method = "keyPressed", at = @At("TAIL"))
+    @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
     private void invsort$keyPressed(int keycode, int scancode, int modifiers, CallbackInfoReturnable callbackInfoReturnable) {
         if (InventorySorterMod.keyBinding.matchesKey(keycode, scancode)) {
             InventorySortPacket.sendSortPacket(InventoryHelper.isPlayerOnlyInventory(this));
+            callbackInfoReturnable.cancel();
         }
     }
 


### PR DESCRIPTION
Closes #10 

I don't understand `AbstractContainerScreen#mouseClicked` enough to know exactly why this works, but it does.

My theory:
`ServerPlayNetworkHandler#onPickFromInventory` gets called if "Pick Block" is bound and activated. Maybe when that runs last it clobbers a pending inventory update? Then by doing the sort logic last, "Pick Block" works and the inventory is updated because it's marked dirty again?