### PR TITLE
fix enchanted book sorting on 1.16 (fixes #28)

### DIFF
--- a/src/main/java/net/kyrptonaught/inventorysorter/SortCases.java
+++ b/src/main/java/net/kyrptonaught/inventorysorter/SortCases.java
@@ -55,7 +55,7 @@ public class SortCases {
             if (enchantID == null) continue;
             Enchantment enchant = Registry.ENCHANTMENT.get(enchantID);
             if (enchant == null) continue;
-            names.add(enchant.getName(enchants.getCompound(i).getInt("lvl")).asString());
+            names.add(enchant.getName(enchantTag.getInt("lvl")).getString());
         }
         Collections.sort(names);
         for (String enchant : names) {


### PR DESCRIPTION
This is a very simple fix to enchanted books sorting not working on 1.16. The issue was that we were calling `asString()` on the `Text` component, instead of `getString()`.