### PR TITLE
[feat request] sort player (and mob) heads by owner name

### DIFF
--- a/src/main/java/net/kyrptonaught/inventorysorter/SortCases.java
+++ b/src/main/java/net/kyrptonaught/inventorysorter/SortCases.java
@@ -28,17 +28,32 @@ public class SortCases {
             case NAME:
                 if (stack.hasCustomName()) return stack.getName() + itemName;
         }
+
+
         return itemName;
     }
 
     private static String specialCases(ItemStack stack) {
+        Item item = stack.getItem();
+        CompoundTag tag = stack.getTag();
+
+        if (tag.contains("SkullOwner"))
+            return playerHeadCase(stack);
         if (stack.getCount() != stack.getMaxCount())
             return stackSize(stack);
-        if (stack.getItem() instanceof EnchantedBookItem)
+        if (item instanceof EnchantedBookItem)
             return enchantedBookNameCase(stack);
-        if (stack.getItem() instanceof ToolItem)
+        if (item instanceof ToolItem)
             return toolDuribilityCase(stack);
-        return stack.getItem().toString();
+        return item.toString();
+    }
+
+    private static String playerHeadCase(ItemStack stack) {
+        CompoundTag tag = stack.getTag();
+        CompoundTag skullOwner = tag.getCompound("SkullOwner");
+        String ownerName = skullOwner.getString("Name");
+
+        return ownerName + stack.getCount();
     }
 
     private static String stackSize(ItemStack stack) {

--- a/src/main/java/net/kyrptonaught/inventorysorter/SortCases.java
+++ b/src/main/java/net/kyrptonaught/inventorysorter/SortCases.java
@@ -53,7 +53,13 @@ public class SortCases {
         CompoundTag skullOwner = tag.getCompound("SkullOwner");
         String ownerName = skullOwner.getString("Name");
 
-        return ownerName + stack.getCount();
+        // this is duplicated logic, so we should probably refactor
+        String count = "";
+        if (stack.getCount() != stack.getMaxCount()) {
+            count = Integer.toString(stack.getCount());
+        }
+
+        return ownerName + count;
     }
 
     private static String stackSize(ItemStack stack) {

--- a/src/main/java/net/kyrptonaught/inventorysorter/SortCases.java
+++ b/src/main/java/net/kyrptonaught/inventorysorter/SortCases.java
@@ -59,7 +59,7 @@ public class SortCases {
             count = Integer.toString(stack.getCount());
         }
 
-        return ownerName + count;
+        return stack.getItem().toString() + " " + ownerName + count;
     }
 
     private static String stackSize(ItemStack stack) {

--- a/src/main/java/net/kyrptonaught/inventorysorter/SortCases.java
+++ b/src/main/java/net/kyrptonaught/inventorysorter/SortCases.java
@@ -37,7 +37,7 @@ public class SortCases {
         Item item = stack.getItem();
         CompoundTag tag = stack.getTag();
 
-        if (tag.contains("SkullOwner"))
+        if (tag != null && tag.contains("SkullOwner"))
             return playerHeadCase(stack);
         if (stack.getCount() != stack.getMaxCount())
             return stackSize(stack);


### PR DESCRIPTION
This implements sorting player (and mob) heads by their owner names, be it a mob or a player.

Before:
![image](https://user-images.githubusercontent.com/2119933/102573512-5ac0f300-40cd-11eb-91da-6bf6c17bd6e6.png)

After:
![image](https://user-images.githubusercontent.com/2119933/102574156-da02f680-40ce-11eb-9f1c-3148b127c10d.png)
