### PR TITLE
Add Fabric Waystones to downloadable blacklist

### DIFF
--- a/DownloadableBlacklist.json5
+++ b/DownloadableBlacklist.json5
@@ -4,7 +4,7 @@
     "conjuring:soulfire_forge",
     "spectrum:pedestal",
     "adorn:trading_station",
-   "guild:quest_screen"
+    "guild:quest_screen"
   ],
   // Neither the opened inventory, nor your player inventory will be sortable when this inventory is opened
   "hideSortBtnsList": [
@@ -21,6 +21,9 @@
     "dankstorage:portable_dank_5",
     "dankstorage:portable_dank_6",
     "dankstorage:portable_dank_7",
-   "guild:quest_screen"
+    "fwaystones:waystone",
+    "fwaystones:pocket_wormhole",
+    "fwaystones:abyss",
+    "guild:quest_screen"
   ]
 }


### PR DESCRIPTION
The GUIs in Fabric Waystones don't have an accessible inventory system, so the sort button only gets in the way:
![image](https://user-images.githubusercontent.com/26803198/221988617-d65a4e02-f317-4c03-b32b-9e04c5ab814b.png)
Pardon if I misunderstood anything, I only had a quick 1 minute look before opening this PR :)